### PR TITLE
chore: bump micronaut version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-micronautVersion=4.8.2
+micronautVersion=4.8.3
 z4jVersion=0.0.3-SNAPSHOT
 org.gradle.jvmargs=-Xmx4096M


### PR DESCRIPTION
migrate to 4.8.3 from 4.8.2
