### PR TITLE
Adding guide/explanation on how the OpenAPI Generator works.

### DIFF
--- a/HOW_THIS_WORKS.md
+++ b/HOW_THIS_WORKS.md
@@ -1,0 +1,18 @@
+# How This Works
+This is a basic explanation for contributors on how the OpenAPI generator builds the endpoints and why it is being used.
+
+## How does the OpenAPI Generator Work?
+The OpenAPI Generator is a tool that takes `.yaml` files (in our case [z4j.yaml]) and uses them as a blueprint to generate code.
+
+The structure of these files follow the [OpenAPI Specification (OAS)].
+
+## Why Use the OpenAPI Generator?
+Using the generator has advantages, such as:
+* Saves time by automatically generating repetitive and verbose code
+* Reduces the chance of human error in code implementation
+* Ensures consistency across API specifications and implementation, especially for multiple contributors
+* The generator can output to many different programming languages
+
+[z4j.yaml]:src/main/resources/z4j.yaml
+
+[OpenAPI Specification (OAS)]:https://swagger.io/docs/specification/v2_0/basic-structure/


### PR DESCRIPTION
Added HOW_THIS_WORKS.md, which contains a brief explanation on how the OpenAPI generator works, and why we're using it for the project.